### PR TITLE
Refactor notifications receivers

### DIFF
--- a/lib/remark_api/notifications/receivers/android_device.ex
+++ b/lib/remark_api/notifications/receivers/android_device.ex
@@ -23,6 +23,8 @@ defmodule RemarkApi.Notifications.Receivers.AndroidDevice do
   end
 
   defp process_client(device_token, message_json_string) do
-    Receivers.GcmServer.send(device_token, message_json_string)
+    spawn fn ->
+      Receivers.GcmServer.send(device_token, message_json_string)
+    end
   end
 end

--- a/lib/remark_api/notifications/receivers/websocket.ex
+++ b/lib/remark_api/notifications/receivers/websocket.ex
@@ -22,6 +22,8 @@ defmodule RemarkApi.Notifications.Receivers.Websocket do
   end
 
   defp process_client(client_pid, message_json_string) do
-    send client_pid, {:message, message_json_string}
+    spawn fn ->
+      send(client_pid, {:message, message_json_string})
+    end
   end
 end


### PR DESCRIPTION
Before we had sending notifications to each client in the single process
but if one of the sending procedure fail the whole process will be
terminated. So the very simple improvement has been done: each sending
do in the spawned process.